### PR TITLE
terraform: add required_version constraint

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5"
+
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"


### PR DESCRIPTION
Add `required_version = ">= 1.5"` to the `terraform` block to prevent running with older incompatible Terraform versions.