### PR TITLE
terraform: pin cloudflare provider to 5.19.1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 5"
+      version = "5.19.1"
     }
   }
 }


### PR DESCRIPTION
Pins the Cloudflare Terraform provider to an exact version (`5.19.1`) instead of the loose constraint `~> 5`.

This ensures reproducible infrastructure plans and prevents unexpected provider updates during `terraform init`.