### PR TITLE
Bump yarn from 4.12.0 to 4.15.0

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,7 +1,14 @@
-nodeLinker: node-modules
+approvedGitRepositories:
+  - "**"
 
 enableGlobalCache: true
+
+enableScripts: true
 
 logFilters:
   - code: YN0002 # https://yarnpkg.com/advanced/error-codes#yn0002---missing_peer_dependency
     level: error
+
+nodeLinker: node-modules
+
+npmMinimalAgeGate: "3d"

--- a/package.json
+++ b/package.json
@@ -26,5 +26,5 @@
   "engines": {
     "node": "24"
   },
-  "packageManager": "yarn@4.12.0"
+  "packageManager": "yarn@4.15.0+sha512.07ec708ac11e2eaa4ea2b04cfbb272812f7e74a753f1595eaef4486c663a98306a30cca3e6fc40f7a0b168dcfb3a2490b6a5e0501e20fb69cc36f563dd161c53"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 10
   cacheKey: 10c0
 
 "@acemir/cssom@npm:^0.9.31":


### PR DESCRIPTION
Upgrades the package manager from Yarn 4.12.0 to 4.15.0.

### Changes
- `.yarnrc.yml`: added `approvedGitRepositories`, `enableScripts`, `npmMinimalAgeGate` settings; reordered keys
- `package.json`: updated `packageManager` field with new version and checksum
- `yarn.lock`: bumped lockfile metadata version from 8 to 10